### PR TITLE
Add support for reading source text from STDIN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    paths-ignore:
+    - 'docs/**'
+    - '*.md'
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Add Crystal repos
+      run: curl -sSL https://dist.crystal-lang.org/apt/setup.sh | sudo bash
+
+    - name: Install crystal
+      run: sudo apt install -y crystal libevent-dev libpcre3-dev libreadline-dev libssl-dev
+
+    - name: Install dependencies
+      run: shards install
+
+    - name: Run tests
+      run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       run: curl -sSL https://dist.crystal-lang.org/apt/setup.sh | sudo bash
 
     - name: Install crystal
-      run: sudo apt install -y crystal libevent-dev libpcre3-dev libreadline-dev libssl-dev
+      run: sudo apt install -y crystal libevent-dev libpcre3-dev libreadline-dev libssl-dev libyaml-dev
 
     - name: Install dependencies
       run: shards install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,0 @@
-language: crystal

--- a/spec/io_scanner_spec.cr
+++ b/spec/io_scanner_spec.cr
@@ -127,6 +127,19 @@ describe Fincher::IOScanner, "#rest" do
   end
 end
 
+describe Fincher::IOScanner, "#gets_to_end" do
+  it "returns the remainder of the string from the offset" do
+    s = Fincher::IOScanner.new(::IO::Memory.new("this is a string"))
+    s.rest.should eq("this is a string")
+
+    s.scan(/this is a /)
+    s.rest.should eq("string")
+
+    s.scan(/string/)
+    s.rest.should eq("")
+  end
+end
+
 describe Fincher::IOScanner, "#[]" do
   it "allows access to subgroups of the last match" do
     s = Fincher::IOScanner.new(::IO::Memory.new("Fri Dec 12 1975 14:39"))

--- a/spec/strategies/displacement/m_word_offset_spec.cr
+++ b/spec/strategies/displacement/m_word_offset_spec.cr
@@ -11,10 +11,12 @@ describe Fincher::DisplacementStrategies::MWordOffset do
         3
       )
       source_text_scanner = Fincher::IOScanner.new(IO::Memory.new("lorem ipsum test blerg smorgasboorg"))
+      output_io = IO::Memory.new
 
       it "adds the configured offset to the StringScanner#offset" do
-        m_word_offsetter.advance_to_next!(source_text_scanner, Char::ZERO)
+        m_word_offsetter.advance_to_next!(source_text_scanner, Char::ZERO, io: output_io)
         source_text_scanner.offset.should eq(17)
+        output_io.to_s.should eq("lorem ipsum test ")
       end
     end
 
@@ -25,10 +27,11 @@ describe Fincher::DisplacementStrategies::MWordOffset do
         10
       )
       source_text_scanner = Fincher::IOScanner.new(IO::Memory.new("lorem"))
+      output_io = IO::Memory.new
 
       it "raises an exception" do
         expect_raises(Fincher::StrategyNotFeasibleError) do
-          m_word_offsetter.advance_to_next!(source_text_scanner, Char::ZERO)
+          m_word_offsetter.advance_to_next!(source_text_scanner, Char::ZERO, io: output_io)
         end
       end
     end

--- a/spec/strategies/displacement/matching_char_offset_spec.cr
+++ b/spec/strategies/displacement/matching_char_offset_spec.cr
@@ -11,10 +11,12 @@ describe Fincher::DisplacementStrategies::MatchingCharOffset do
         3
       )
       source_text_scanner = Fincher::IOScanner.new(IO::Memory.new("lorem ipsum test blerg smorgasboorg"))
+      output_io = IO::Memory.new
 
       it "adds the configured offset to the StringScanner#offset" do
-        matching_char_offsetter.advance_to_next!(source_text_scanner, 'r')
+        matching_char_offsetter.advance_to_next!(source_text_scanner, 'r', io: output_io)
         source_text_scanner.offset.should eq(20)
+        output_io.to_s.should eq("lorem ipsum test ble")
       end
     end
 
@@ -25,10 +27,11 @@ describe Fincher::DisplacementStrategies::MatchingCharOffset do
         10
       )
       source_text_scanner = Fincher::IOScanner.new(IO::Memory.new("lorem"))
+      output_io = IO::Memory.new
 
       it "raises an exception" do
         expect_raises(Fincher::StrategyNotFeasibleError) do
-          matching_char_offsetter.advance_to_next!(source_text_scanner, 'r')
+          matching_char_offsetter.advance_to_next!(source_text_scanner, 'r', io: output_io)
         end
       end
     end

--- a/spec/strategies/displacement/n_char_offset_spec.cr
+++ b/spec/strategies/displacement/n_char_offset_spec.cr
@@ -11,10 +11,12 @@ describe Fincher::DisplacementStrategies::NCharOffset do
         10
       )
       source_text_scanner = Fincher::IOScanner.new(IO::Memory.new("lorem ipsum test"))
+      output_io = IO::Memory.new
 
       it "adds the configured offset to the StringScanner#offset" do
-        n_char_offsetter.advance_to_next!(source_text_scanner, Char::ZERO)
+        n_char_offsetter.advance_to_next!(source_text_scanner, Char::ZERO, io: output_io)
         source_text_scanner.pos = 10
+        output_io.to_s.should eq("lorem ipsu")
       end
     end
 
@@ -25,10 +27,11 @@ describe Fincher::DisplacementStrategies::NCharOffset do
         10
       )
       source_text_scanner = Fincher::IOScanner.new(IO::Memory.new("lorem"))
+      output_io = IO::Memory.new
 
       it "raises an exception" do
         expect_raises(Fincher::StrategyNotFeasibleError) do
-          n_char_offsetter.advance_to_next!(source_text_scanner, Char::ZERO)
+          n_char_offsetter.advance_to_next!(source_text_scanner, Char::ZERO, io: output_io)
         end
       end
     end

--- a/spec/transformer_spec.cr
+++ b/spec/transformer_spec.cr
@@ -21,7 +21,7 @@ describe Fincher::Transformer do
       transformer.transform(transformed)
 
       transformed.to_s.should eq(
-        "I am a test sentenceh The quick brown foe jumps over the lazl dog. That dog is llzy as fuck. God damo. How many dogs there gotta be that be like this man come on son. Why."
+        "I am a test sentenceh The quick brown foxejumps over the lazy log. That dog is lazylas fuck. God damn. How many dogs there gotta be that be like this man come on son. Why."
       )
     end
   end

--- a/src/fincher/cli.cr
+++ b/src/fincher/cli.cr
@@ -16,8 +16,8 @@ module Fincher
       @seed : UInt32?
 
       class Options
-        arg "source_text_file", required: true, desc: "source text file"
         arg "message", required: true, desc: "message"
+        arg "source_text_file", required: false, desc: "source text file. STDIN, if omitted"
         string "--seed",
                var: "NUMBER",
                required: false,
@@ -57,7 +57,12 @@ module Fincher
         plaintext_scanner = ::IO::Memory.new(args.message)
         displacement_strategy = options.displacement_strategy
         replacement_strategy = options.replacement_strategy
-        source_file = File.open(args.source_text_file)
+
+        source_file = if source_text_file = args.source_text_file?
+          File.open(source_text_file)
+        else
+          STDIN
+        end
 
         transformer = Fincher::Transformer.new(
           plaintext_scanner,
@@ -122,7 +127,7 @@ module Fincher
       end
 
       def run
-        puts "Fincher #{version}"
+        puts "fincher #{version}"
       end
     end
   end

--- a/src/fincher/strategies/displacement/base.cr
+++ b/src/fincher/strategies/displacement/base.cr
@@ -7,7 +7,7 @@ module Fincher
       def initialize(@plaintext_scanner : Fincher::IO, @seed : UInt32)
       end
 
-      abstract def advance_to_next!(scanner : Fincher::IOScanner, msg_char : Char) : Fincher::IOScanner
+      abstract def advance_to_next!(scanner : Fincher::IOScanner, msg_char : Char, io : ::IO) : Fincher::IOScanner
 
       abstract def is_feasible?(scanner : Fincher::IOScanner)
     end

--- a/src/fincher/strategies/displacement/m_word_offset.cr
+++ b/src/fincher/strategies/displacement/m_word_offset.cr
@@ -6,9 +6,9 @@ module Fincher
       def initialize(@plaintext_scanner : Fincher::IO, @seed : UInt32, @offset : Int32)
       end
 
-      def advance_to_next!(scanner : Fincher::IOScanner, msg_char : Char) : Fincher::IOScanner
+      def advance_to_next!(scanner : Fincher::IOScanner, msg_char : Char, io : ::IO) : Fincher::IOScanner
         offset.times do
-          scanner.scan_until(/\b[\w\-\']+\b\W+\b/im)
+          io << scanner.scan_until(/\b[\w\-\']+\b\W+\b/im)
 
           raise StrategyNotFeasibleError.new(
             "Cannot advance #{offset} words at scanner position #{scanner.pos}"

--- a/src/fincher/strategies/displacement/matching_char_offset.cr
+++ b/src/fincher/strategies/displacement/matching_char_offset.cr
@@ -6,15 +6,20 @@ module Fincher
       def initialize(@plaintext_scanner : Fincher::IO, @seed : UInt32, @offset : Int32)
       end
 
-      def advance_to_next!(scanner : Fincher::IOScanner, msg_char : Char) : Fincher::IOScanner
+      def advance_to_next!(scanner : Fincher::IOScanner, msg_char : Char, io : IO) : Fincher::IOScanner
         offset.times do
-          scanner.scan_until(/\b[\w\-\']+\b\W+\b/im)
+          io << scanner.scan_until(/\b[\w\-\']+\b\W+\b/im)
 
           raise StrategyNotFeasibleError.new(
             "Cannot advance #{offset} words for character '#{msg_char}' at scanner position #{scanner.pos}"
           ) unless is_feasible?(scanner)
         end
-        scanner.skip_until(/#{msg_char}/i)
+
+        matching_char_str = scanner.scan_until(/#{msg_char}/i)
+        raise StrategyNotFeasibleError.new(
+          "Cound not find character '#{msg_char}' after #{offset} words at scanner position #{scanner.pos}"
+        ) unless matching_char_str
+        io << matching_char_str[0...-1]
         scanner.offset = scanner.offset - 1
         scanner
       end

--- a/src/fincher/strategies/displacement/n_char_offset.cr
+++ b/src/fincher/strategies/displacement/n_char_offset.cr
@@ -6,17 +6,18 @@ module Fincher
       def initialize(@plaintext_scanner : Fincher::IO, @seed : UInt32, @offset : Int32)
       end
 
-      def advance_to_next!(scanner : Fincher::IOScanner, msg_char : Char) : Fincher::IOScanner
+      def advance_to_next!(scanner : Fincher::IOScanner, msg_char : Char, io : IO) : Fincher::IOScanner
         raise StrategyNotFeasibleError.new(
           "Cannot advance #{offset} chars at scanner position #{scanner.pos}"
         ) unless is_feasible?(scanner)
 
-        scanner.pos += offset
+        io << scanner.scan(/.{#{offset}}/)
+
         scanner
       end
 
       def is_feasible?(scanner : Fincher::IOScanner)
-        scanner.size > scanner.pos + offset
+        scanner.stdin? || (scanner.size > scanner.pos + offset)
       end
     end
   end

--- a/src/fincher/transformer.cr
+++ b/src/fincher/transformer.cr
@@ -21,26 +21,16 @@ module Fincher
 
       plaintext_scanner.each_char do |msg_char|
         # Advance position
-        displacer.advance_to_next!(source_scanner, msg_char)
-
-        # Grab previously unmodified section
-        read_size = source_scanner.offset - current_offset
-        source_scanner.seek(current_offset)
-
-        if read_size > 0
-          unmodified = source_scanner.read_string(read_size)
-          io << unmodified
-        end
+        displacer.advance_to_next!(source_scanner, msg_char, io: io)
 
         # Replace the next char
         replaced_char = replacer.replace(msg_char)
         io << replaced_char
 
-        # Record this offset (+ 1 skipping the current char)
-        current_offset = source_scanner.offset + 1
+        # Skip the current char, since we just replace it
+        source_scanner.skip(1)
       end
 
-      source_scanner.skip(1)
       io << source_scanner.gets_to_end
       io
     end


### PR DESCRIPTION
Requires placing some constraints on backwards movement on the
stream, as STDIN is not rewindable. However, we can look backwards
in the buffer if we need to for operational purposes, which should be
sufficent for most strategies.