### PR TITLE
Update to crystal 1.17.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
 
     - uses: crystal-lang/install-crystal@v1
       with:
-        crystal: 1.10.0
+        crystal: 1.17.1
 
     - name: Install dependencies
       run: shards install

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-crystal 1.10.0
+crystal 1.17.1

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The inspiration for `fincher` comes from "Panopticon", Season 4 Episode 1 in
 Person of Interest, in which _The Machine_ encodes a message as typos in the
 dissertation of one of the main characters, Harold Finch.
 
-`fincher` is currently `0.2.2` and considered an **experiment**
+`fincher` is currently `0.3.0` and considered an **experiment**
 and a project for **funsies**. I am very interested in contributions & ideas!
 
 ## Disclaimer
@@ -174,19 +174,16 @@ characters close to a message character on the keyboard.
 
 ## Limitations
 
-`fincher` is early stages and has some notable limitations:
+`fincher` has some notable limitations:
 
 * The current displacement and replacement strategies are not context-aware.
   i.e. they do not make judgements based on the content of the source text and
-  whether the replacement or displacement makes sense grammatically. This will
-  probably change.
-* Source text scanning (rightly or wrongly) happens on a rotating
-  4K buffer (so you could feed it multi-GB source text, if you wanted to) and
-  the `IOScanner` does not handle regex matching across buffer boundaries.
-  Therefore, the `--[word|char]-offset` parameters are not applied exactly, but
-  will make minimum guarantees about the offset.
-* Does not yet take input from `STDIN`, so it cannot be piped to yet. (It does
-  however, output to `STDOUT`.)
+  whether the replacement or displacement makes sense grammatically.
+* Source text scanning happens on a rotating 4K buffer (so you could feed it
+  multi-GB source text, if you wanted to), but the `IOScanner` does not handle
+  regex matching across buffer boundaries. Therefore, the `--[word|char]-offset`
+  parameters are not applied exactly, but will make minimum guarantees about the
+  offset.
 
 ## Development
 

--- a/shard.lock
+++ b/shard.lock
@@ -4,19 +4,7 @@ shards:
     git: https://github.com/schovi/baked_file_system.git
     version: 0.11.0
 
-  callback:
-    git: https://github.com/amberframework/callback.git
-    version: 0.7.1
-
-  cli:
-    git: https://github.com/amberframework/cli.git
-    version: 0.9.3
-
-  optarg:
-    git: https://github.com/amberframework/optarg.git
-    version: 0.8.0
-
-  string_inflection:
-    git: https://github.com/mosop/string_inflection.git
-    version: 0.2.1
+  commander:
+    git: https://github.com/mrrooijen/commander.git
+    version: 0.4.0
 

--- a/shard.lock
+++ b/shard.lock
@@ -2,7 +2,7 @@ version: 2.0
 shards:
   baked_file_system:
     git: https://github.com/schovi/baked_file_system.git
-    version: 0.9.8+git.commit.7183bfde8d86a976a6912f582b51cbd1783456af
+    version: 0.11.0
 
   callback:
     git: https://github.com/amberframework/callback.git

--- a/shard.yml
+++ b/shard.yml
@@ -7,7 +7,7 @@ authors:
 dependencies:
   baked_file_system:
     github: schovi/baked_file_system
-    branch: master
+    version: ~> 0.11.0
 
   cli:
     github: amberframework/cli

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: fincher
-version: 0.2.2
+version: 0.3.0
 
 authors:
   - Max Fierke <max@maxfierke.com>
@@ -9,14 +9,14 @@ dependencies:
     github: schovi/baked_file_system
     version: ~> 0.11.0
 
-  cli:
-    github: amberframework/cli
-    version: ~> 0.9.3
+  commander:
+    github: mrrooijen/commander
+    version: ~> 0.4.0
 
 targets:
   fincher:
     main: src/cli.cr
 
-crystal: ">= 1.8.0"
+crystal: ">= 1.14.0"
 
 license: MIT

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -1,5 +1,5 @@
 require "./fincher"
 
 Colorize.on_tty_only!
-Fincher.debug = true
-Fincher::CLI.run ARGV
+Fincher.debug = {{flag?(:debug)}}
+Fincher::CLI.run!(ARGV)

--- a/src/fincher.cr
+++ b/src/fincher.cr
@@ -1,6 +1,6 @@
 require "baked_file_system"
 require "colorize"
-require "cli"
+require "commander"
 require "random/secure"
 require "yaml"
 require "./fincher/*"

--- a/src/fincher/cli.cr
+++ b/src/fincher/cli.cr
@@ -1,64 +1,23 @@
 module Fincher
-  class CLI < ::Cli::Supercommand
-    version Fincher::VERSION
-    command_name "fincher"
+  class CLI
+    @cli : Commander::Command
 
-    class Options
-      help
-    end
+    getter :cli
 
-    class Help
-      header "Encodes a message as typos within a source text."
-      footer "Copyright (c) 2017 Max Fierke. Licensed under The MIT License."
-    end
-
-    class Encode < ::Cli::Command
+    class Encode
       @seed : UInt32?
 
-      class Options
-        arg "message", required: true, desc: "message"
-        arg "source_text_file", required: false, desc: "source text file. STDIN, if omitted"
-        string "--seed",
-               var: "NUMBER",
-               required: false,
-               default: "",
-               desc: "seed value. randomly generated if omitted"
-        string "--displacement-strategy",
-               var: "STRING",
-               default: "matching-char-offset",
-               desc: "displacement strategy (Options: char-offset, word-offset, matching-char-offset)"
-        string "--replacement-strategy",
-               var: "STRING",
-               default: "keymap",
-               desc: "replacement strategy (Options: n-shifter, keymap)"
-        string "--char-offset",
-               var: "NUMBER",
-               default: "130",
-               desc: "character gap between typos (Displacement Strategies: char-offset)"
-        string "--word-offset",
-               var: "NUMBER",
-               default: "38",
-               desc: "word gap between typos (Displacement Strategies: word-offset, matching-char-offset)"
-        string "--codepoint-shift",
-               var: "NUMBER",
-               default: "7",
-               desc: "codepoints to shift (Replacement Strategies: n-shifter)"
-        string "--keymap",
-               var: "STRING",
-               default: "en-US_qwerty",
-               desc: "Keymap definition to use for keymap replacement strategy"
-      end
-
-      class Help
-        caption "encode message"
+      def initialize(options : Commander::Options, args : Commander::Arguments)
+        @options = options
+        @args = args
       end
 
       def run(io = STDOUT)
-        plaintext_scanner = ::IO::Memory.new(args.message)
-        displacement_strategy = options.displacement_strategy
-        replacement_strategy = options.replacement_strategy
+        plaintext_scanner = ::IO::Memory.new(args[0])
+        displacement_strategy = options.string["displacement_strategy"]
+        replacement_strategy = options.string["replacement_strategy"]
 
-        source_file = if source_text_file = args.source_text_file?
+        source_file = if source_text_file = args[1]
           File.open(source_text_file)
         else
           STDIN
@@ -70,22 +29,22 @@ module Fincher
           displacement_strategy_for(displacement_strategy, plaintext_scanner, options),
           replacement_strategy_for(replacement_strategy, options)
         ).transform(io)
-      rescue e : ::Fincher::Error
-        Fincher.error e.message
       ensure
         source_file.close if source_file
       end
 
+      private getter :options, :args
+
       private def displacement_strategy_for(strategy, plaintext_scanner, options)
         case strategy
         when "word-offset"
-          word_offset = options.word_offset.to_i
+          word_offset = options.int["word_offset"].to_i32
           Fincher::DisplacementStrategies::MWordOffset.new(plaintext_scanner, seed, word_offset)
         when "char-offset"
-          char_offset = options.char_offset.to_i
+          char_offset = options.int["char_offset"].to_i32
           Fincher::DisplacementStrategies::NCharOffset.new(plaintext_scanner, seed, char_offset)
         when "matching-char-offset"
-          word_offset = options.word_offset.to_i
+          word_offset = options.int["word_offset"].to_i32
           Fincher::DisplacementStrategies::MatchingCharOffset.new(plaintext_scanner, seed, word_offset)
         else
           raise StrategyDoesNotExistError.new(
@@ -97,10 +56,10 @@ module Fincher
       private def replacement_strategy_for(strategy, options)
         case strategy
         when "n-shifter"
-          codepoint_shift = options.codepoint_shift.to_i
+          codepoint_shift = options.int["codepoint_shift"].to_i32
           Fincher::ReplacementStrategies::NShifter.new(seed, codepoint_shift)
         when "keymap"
-          keymap_name = options.keymap
+          keymap_name = options.string["keymap"]
           keymap = Fincher::Types::Keymap.load!(keymap_name)
           Fincher::ReplacementStrategies::Keymap.new(seed, keymap)
         else
@@ -111,7 +70,7 @@ module Fincher
       end
 
       private def seed
-        @seed ||= options.seed.empty? ? generate_seed : options.seed.to_u32
+        @seed ||= options.int["seed"] == 0 ? generate_seed : options.int["seed"].to_u32
       end
 
       private def generate_seed
@@ -121,14 +80,121 @@ module Fincher
       end
     end
 
-    class Version < ::Cli::Command
-      class Help
-        caption "print the version"
-      end
+    def initialize
+      @cli = Commander::Command.new do |cmd|
+        cmd.use = "fincher"
 
-      def run
-        puts "fincher #{version}"
+        cmd.long = <<-DESC
+Encodes a message as typos within a source text.
+
+  Version v#{Fincher::VERSION}
+  Compiled at #{Fincher::COMPILED_AT}
+
+  Documentation: https://github.com/maxfierke/fincher
+  Issue tracker: https://github.com/maxfierke/fincher/issues
+DESC
+
+        cmd.flags.add do |flag|
+          flag.name = "version"
+          flag.short = "-V"
+          flag.long = "--version"
+          flag.default = false
+          flag.description = "prints version number."
+          flag.persistent = true
+        end
+
+        cmd.commands.add do |encode_cmd|
+          encode_cmd.use = "encode MESSAGE [SRC_FILE]"
+          encode_cmd.short = "encode a message"
+          encode_cmd.long = <<-DESC
+          Encodes MESSAGE in the contents of a file provided by SRC_FILE or STDIN, if not provided.
+
+            Output will be printed to standard output
+          DESC
+
+          encode_cmd.flags.add do |flag|
+            flag.name = "seed"
+            flag.long = "--seed"
+            flag.default = 0
+            flag.description = "seed value. randomly generated if omitted"
+          end
+
+          encode_cmd.flags.add do |flag|
+            flag.name = "displacement_strategy"
+            flag.long = "--displacement-strategy"
+            flag.default = "matching-char-offset"
+            flag.description = "displacement strategy (Options: char-offset, word-offset, matching-char-offset)"
+          end
+
+          encode_cmd.flags.add do |flag|
+            flag.name = "replacement_strategy"
+            flag.long = "--replacement-strategy"
+            flag.default = "keymap"
+            flag.description = "replacement strategy (Options: n-shifter, keymap)"
+          end
+
+          encode_cmd.flags.add do |flag|
+            flag.name = "char_offset"
+            flag.long = "--char-offset"
+            flag.default = 130
+            flag.description = "character gap between typos (Displacement Strategies: char-offset)"
+          end
+
+          encode_cmd.flags.add do |flag|
+            flag.name = "word_offset"
+            flag.long = "--word-offset"
+            flag.default = 38
+            flag.description = "word gap between typos (Displacement Strategies: word-offset, matching-char-offset)"
+          end
+
+          encode_cmd.flags.add do |flag|
+            flag.name = "codepoint_shift"
+            flag.long = "--codepoint-shift"
+            flag.default = 7
+            flag.description = "codepoints to shift (Replacement Strategies: n-shifter)"
+          end
+
+          encode_cmd.flags.add do |flag|
+            flag.name = "keymap"
+            flag.long = "--keymap"
+            flag.default = "en-US_qwerty"
+            flag.description = "Keymap definition to use for keymap replacement strategy"
+          end
+
+          encode_cmd.run do |options, arguments|
+            if arguments.empty?
+              Fincher.error "message is required"
+              next
+            end
+
+            if arguments.size > 2
+              Fincher.error "unexpected arguments: expected 1-2, received #{arguments.size}"
+              next
+            end
+
+            Encode.new(options, arguments).run
+          end
+        end
+
+        cmd.run do |options, _|
+          if options.bool["version"]
+            puts Fincher::VERSION
+            exit
+          end
+
+          puts cmd.help
+        end
       end
+    end
+
+    def self.run!(argv)
+      new.run!(argv)
+    end
+
+    def run!(argv)
+      Commander.run(cli, argv)
+    rescue e : ::Fincher::Error
+      Fincher.error e.message
     end
   end
 end

--- a/src/fincher/version.cr
+++ b/src/fincher/version.cr
@@ -1,3 +1,7 @@
 module Fincher
-  VERSION = "0.1.1"
+  # Date and time when binary was compiled
+  COMPILED_AT = {{`date -u`.chomp.stringify}}
+
+  # `fincher` version
+  VERSION = {{`shards version`.chomp.stringify}}
 end


### PR DESCRIPTION
Updating past 1.13 necessitated replacing or updating some libraries. `amberframework/cli` has been replaced with `mrrooijen/commander`, mostly for my own convenience as other projects of mine us it.

This will be made into a 0.3.0 release, with some extremely minor breaking changes related to the flags.